### PR TITLE
get logging working again

### DIFF
--- a/tf/init.sh
+++ b/tf/init.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 apt-get update
 apt-get upgrade -q -y
 
-apt-get install -q -y nginx certbot python3-certbot-nginx
+apt-get install -q -y nginx certbot python3-certbot-nginx logrotate
 snap install aws-cli --classic
 
 ## Disable IP website
@@ -95,7 +95,7 @@ cat <<LOGROTATE > /etc/logrotate.d/nginx
   compress
   daily
   dateext
-  dateformat -%Y-%m-%d-$INSTANCE_ID
+  dateformat -%Y-%m-%d-%H-%M-%S-$INSTANCE_ID
   nomail
   missingok
   sharedscripts
@@ -125,7 +125,7 @@ set -euo pipefail
 cd /var/log/nginx
 for f in access.log error.log; do
   gzip -9 \$f
-  /usr/bin/aws s3 cp \$f.gz s3://cuddly-octo-palm-tree/logs/\$f-\$(date +%Y-%m-%d)-$INSTANCE_ID-shutdown.gz
+  aws s3 cp \$f.gz s3://cuddly-octo-palm-tree/logs/\$f-\$(date +%Y-%m-%d-%H-%M-%S)-$INSTANCE_ID-shutdown.gz
 done
 SAVE_LOGS
 chmod +x $SERVICE


### PR DESCRIPTION
My "logs" S3 bucket hadn't received any new logs since 2024-04-25. After
a couple hours of debugging, here is what happened:

1. On 2024-04-12 I switched to the new "preview" Ubuntu 24.04 images as
   part of #12. From that point on, the "shutdown hook" uploading the
   logs right before the machine shuts down was no longer working, because
   in #12 we switch from getting `aws` from `apt` to getting it from
   `snap`, and it is thus stored at `/snap/bin/aws` instead of
   `/usr/bin/aws`. Also, it turns out using a full path there was
   unnecessary as `aws` _is_ on the `$PATH` of that script. I'm not sure
   what I was thinking; how would anything at all work if `/usr/bin` wasn't
   on the `$PATH`? :shrug:
2. On 2024-04-25 I switched from the _testing_ 24.04 to the _stable_
   24.04, but, also, because I wanted to be cute, I guess, from a "full"
   image to a "minimal" one. It turns out one of the (many) things they
   remove from an image to make it "minimal" is `logrotate`, so now I
   install it myself.

As I write this, the blog is still running on a machine I deployed on
2024-04-30, and all of its logs are still there (in a single file). I
have made changes to that machine that mirror the changes in this PR, so
its logs should be preserved.

This means I have lost all of the logs from the machines I deployed on
2024-04-25 and 2024-04-27, as well as _some_ of the logs (specifically:
their last, incomplete day) for the machines I deployed on 2024-04-12
and 2024-04-14.