### PR TITLE
tf: tofu init -migrate-state

### DIFF
--- a/tf/.terraform.lock.hcl
+++ b/tf/.terraform.lock.hcl
@@ -1,6 +1,23 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.9.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Wz1g6VGQE26xKhON1jMmJtpxpI2rgZS6BQ6Bssr2NoE=",
+    "zh:3ae6f70f4e2961e84b89b337d268db0537c6dd0e66d4ccf32cbacc950f7a2807",
+    "zh:4472d1d1629c3c3a6a23672691ed0852bea9fcd9e39a213d388616f93adaaeb0",
+    "zh:4680cb586233b4702abb9fc69615bca6ebe9547ddaceaa0d0439bccc7c773905",
+    "zh:51fd157b544644438ab827e288c8173ecbf31cd92b3b75a8446569db35c00cab",
+    "zh:66aaeb1cb991b982f81564ea52a18ba962b43e86d9e5c76ac591fa522a4a0db6",
+    "zh:d271308040efe8324633810d8c58142310da5f88eb223422fd13daa73e944316",
+    "zh:e56c66588135878081ffa8c2aa5da969d56ff96d4ecb4b0ab6b8b496830cf7c2",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+    "zh:fde7a7d2bda2784e78c0bcc39155e0b09c31dd4a4fa65c26e0e8fe858445ecfc",
+  ]
+}
+
 provider "registry.opentofu.org/dnsimple/dnsimple" {
   version     = "1.5.0"
   constraints = "~> 1.5"

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -1,9 +1,5 @@
 terraform {
-  backend "s3" {
-    bucket         = "sotenj.tfstate"
-    key            = "cuddly"
-    region         = "us-east-1"
-    dynamodb_table = "sotenj.tfstate.locks"
+  backend "local" {
   }
   required_providers {
     aws = {


### PR DESCRIPTION
Moving the state to local, temporarily, in order to move it to
CloudFlare, to continue my crusade to stop giving Amazon _cents_ in
monthly S3 costs.

Note: this does mean I have created a local terraform.tfstate file
again, which I'm deliberately not committing and not gitignore-ing
because it's very temporary.